### PR TITLE
updated interface to the rawClient - formality, not critical

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -101,9 +101,9 @@ export interface IRawAgent {
 
     isUpgraded(): boolean;
 
-    getPublicEndpoint(queryParams?: IQueryParams): Promise<AxiosResponse>;
+    getPublicEndpoint(queryParams?: IQueryParams, configOverride?: IPoloniexRequestConfig): Promise<AxiosResponse>;
 
-    postToPrivateEndpoint(data: IPostBody): Promise<AxiosResponse>;
+    postToPrivateEndpoint(data: IPostBody, configOverride?: IPoloniexRequestConfig): Promise<AxiosResponse>;
 
     signMessage(postBody: IPostBody, privateKey: string): string;
 


### PR DESCRIPTION
I left off the new config parameter from the interface definition of RawClient.  This shouldn't affect anything other than syntax highlighting in certain editors (by affect, I mean fix).